### PR TITLE
企业微信推送增加指定成员 ID，如果不指定，则通知企业全部成员

### DIFF
--- a/job.go
+++ b/job.go
@@ -30,6 +30,7 @@ type Config struct {
 	WxCorpID      string `yaml:"WxCorpID"`      // 企业 ID
 	WxAgentSecret string `yaml:"WxAgentSecret"` // 应用密钥
 	WxAgentID     int    `yaml:"WxAgentID"`     // 应用 ID
+	WxUserId      string `yaml:"WxUserId"`      // 企业微信用户ID，多个用户用|分隔，为空则发送给所有用户
 	MinDelay      int    `yaml:"min_delay"`     // 最小延迟（分钟）
 	MaxDelay      int    `yaml:"max_delay"`     // 最大延迟（分钟）
 	TimeOut       int    `yaml:"time_out"`      // api请求的超时时间(秒）
@@ -167,7 +168,7 @@ func (j *Jobserver) sendSuccessNotification() {
 // sendWeixinMessage method to push message via WeChat
 func (j *Jobserver) sendWeixinMessage(message string) {
 	if j.cfg.WxCorpID != "" && j.cfg.WxAgentSecret != "" {
-		err := weixin.SendMessage(j.cfg.WxCorpID, j.cfg.WxAgentSecret, message, j.cfg.WxAgentID)
+		err := weixin.SendMessage(j.cfg.WxCorpID, j.cfg.WxAgentSecret, message, j.cfg.WxAgentID, j.cfg.WxUserId)
 		if err != nil {
 			log.Errorf("企业微信推送失败: %v", err)
 		}

--- a/lib/weixin/weixin.go
+++ b/lib/weixin/weixin.go
@@ -50,18 +50,15 @@ type Message struct {
 }
 
 // Function to send message
-// Function to send message
-func SendMessage(corpID string, agentSecret string, content string, agentID int) error {
+func SendMessage(corpID string, agentSecret string, content string, agentID int, wxUserId string) error {
 	token, err := GetAccessToken(corpID, agentSecret)
 	if err != nil {
 		return err
 	}
 
-	// Prepare the message payload to send to all users, parties, and tags
+	// Prepare the message payload
 	messagePayload := map[string]interface{}{
-		"touser":  "@all", // 发送给所有用户
-		"toparty": "@all", // 发送给所有部门
-		"totag":   "@all", // 发送给所有标签
+		"touser":  wxUserId, // 直接使用传入的 wxUserId，为空时自动发送给所有用户
 		"msgtype": "text",
 		"text":    map[string]string{"content": content},
 		"agentid": agentID,

--- a/lib/weixin/weixin.go
+++ b/lib/weixin/weixin.go
@@ -58,7 +58,7 @@ func SendMessage(corpID string, agentSecret string, content string, agentID int,
 
 	// Prepare the message payload
 	messagePayload := map[string]interface{}{
-		"touser":  wxUserId, // 直接使用传入的 wxUserId，为空时自动发送给所有用户
+		"touser":  wxUserId, // 直接使用传入的 wxUserId，默认为@all时自动发送给所有用户
 		"msgtype": "text",
 		"text":    map[string]string{"content": content},
 		"agentid": agentID,

--- a/main.go
+++ b/main.go
@@ -25,8 +25,9 @@ func defaultCfg() *Config {
 		WxCorpID:      "",
 		WxAgentSecret: "",
 		WxAgentID:     0,
-		MinDelay:      0, // 默认最小延迟为0分钟
-		MaxDelay:      0, // 默认最大延迟为30分钟
+		WxUserId:      "@all", // 默认为空，表示发送给所有用户
+		MinDelay:      0,  // 默认最小延迟为0分钟
+		MaxDelay:      0,  // 默认最大延迟为30分钟
 		DbPath:        "/data/cookie.db",
 		Version:       "1.1.4",
 		WebVersion:    "1140",
@@ -97,6 +98,9 @@ func main() {
 			log.Fatalf("无法转换 AgentID 环境变量为整数: %v", err)
 		}
 		cfg.WxAgentID = WxAgentID
+	}
+	if os.Getenv("WXUSERID") != "" {
+		cfg.WxUserId = os.Getenv("WXUSERID")
 	}
 	if os.Getenv("MINDELAY") != "" {
 		// 从环境变量读取 AgentID 字符串，并转换为 int

--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ func defaultCfg() *Config {
 		WxCorpID:      "",
 		WxAgentSecret: "",
 		WxAgentID:     0,
-		WxUserId:      "@all", // 默认为空，表示发送给所有用户
+		WxUserId:      "@all", // 默认为@all，表示发送给所有用户
 		MinDelay:      0,  // 默认最小延迟为0分钟
 		MaxDelay:      0,  // 默认最大延迟为30分钟
 		DbPath:        "/data/cookie.db",

--- a/readme.md
+++ b/readme.md
@@ -28,6 +28,7 @@
 | WXCORPID      | 企业微信推送通道用。企业ID                                                 |
 | WXAGENTSECRET | 企业微信推送通道用。应用秘钥                                                 |
 | WXAGENTID     | 企业微信推送通道用。应用ID                                                 |
+| WXUSERID      | 企业微信推送通道用。指定接收消息的成员ID，多个接收者用\|分隔，最多支持1000个。为空则发送给所有成员         |
 | MINDELAY      | 定时任务执行随机延迟，最小延迟（分钟）。默认值0                                       |
 | MAXDELAY      | 定时任务执行随机延迟，最大延迟（分钟）。默认值0                                       |
 | COOKIE_MODE   | cookie更新模式，"normal"(默认）,连续失败6次才删。"strict"，每次失败都会删掉cookie尝试重新登录 |


### PR DESCRIPTION
现在的消息会推送给企微所有人，会对其他成员造成打扰。新增一个环境变量WXUSERID，如果不指定时默认是@all，推送给所有人。删除部门和标签，在touser 是@all 时，部门和标签会被忽略，没有意义

[企微文档](https://developer.work.weixin.qq.com/document/path/90236)
touser	否	指定接收消息的成员，成员ID列表（多个接收者用‘|’分隔，最多支持1000个）。
特殊情况：指定为"@all"，则向该企业应用的全部成员发送
toparty	否	指定接收消息的部门，部门ID列表，多个接收者用‘|’分隔，最多支持100个。
当touser为"@all"时忽略本参数
totag	否	指定接收消息的标签，标签ID列表，多个接收者用‘|’分隔，最多支持100个。
当touser为"@all"时忽略本参数