### PR TITLE
优化企业微信推送功能

### DIFF
--- a/job.go
+++ b/job.go
@@ -30,6 +30,7 @@ type Config struct {
 	WxCorpID      string `yaml:"WxCorpID"`      // 企业 ID
 	WxAgentSecret string `yaml:"WxAgentSecret"` // 应用密钥
 	WxAgentID     int    `yaml:"WxAgentID"`     // 应用 ID
+	WxUserId      string `yaml:"WxUserId"`      // 企业微信用户ID，多个用户用|分隔，为空则发送给所有用户
 	MinDelay      int    `yaml:"min_delay"`     // 最小延迟（分钟）
 	MaxDelay      int    `yaml:"max_delay"`     // 最大延迟（分钟）
 	TimeOut       int    `yaml:"time_out"`      // api请求的超时时间(秒）
@@ -167,7 +168,7 @@ func (j *Jobserver) sendSuccessNotification() {
 // sendWeixinMessage method to push message via WeChat
 func (j *Jobserver) sendWeixinMessage(message string) {
 	if j.cfg.WxCorpID != "" && j.cfg.WxAgentSecret != "" {
-		err := weixin.SendMessage(j.cfg.WxCorpID, j.cfg.WxAgentSecret, message, j.cfg.WxAgentID)
+		err := weixin.SendMessage(j.cfg.WxCorpID, j.cfg.WxAgentSecret, message, j.cfg.WxAgentID, j.cfg.WxUserId)
 		if err != nil {
 			log.Errorf("企业微信推送失败: %v", err)
 		}

--- a/lib/weixin/weixin.go
+++ b/lib/weixin/weixin.go
@@ -50,18 +50,15 @@ type Message struct {
 }
 
 // Function to send message
-// Function to send message
-func SendMessage(corpID string, agentSecret string, content string, agentID int) error {
+func SendMessage(corpID string, agentSecret string, content string, agentID int, wxUserId string) error {
 	token, err := GetAccessToken(corpID, agentSecret)
 	if err != nil {
 		return err
 	}
 
-	// Prepare the message payload to send to all users, parties, and tags
+	// Prepare the message payload
 	messagePayload := map[string]interface{}{
-		"touser":  "@all", // 发送给所有用户
-		"toparty": "@all", // 发送给所有部门
-		"totag":   "@all", // 发送给所有标签
+		"touser":  wxUserId, // 使用传入的 wxUserId，为空时自动发送给所有用户
 		"msgtype": "text",
 		"text":    map[string]string{"content": content},
 		"agentid": agentID,

--- a/main.go
+++ b/main.go
@@ -25,8 +25,9 @@ func defaultCfg() *Config {
 		WxCorpID:      "",
 		WxAgentSecret: "",
 		WxAgentID:     0,
-		MinDelay:      0, // 默认最小延迟为0分钟
-		MaxDelay:      0, // 默认最大延迟为30分钟
+		WxUserId:      "@all", // 默认为空，表示发送给所有用户
+		MinDelay:      0,  // 默认最小延迟为0分钟
+		MaxDelay:      0,  // 默认最大延迟为30分钟
 		DbPath:        "/data/cookie.db",
 		Version:       "1.1.4",
 		WebVersion:    "1140",
@@ -97,6 +98,9 @@ func main() {
 			log.Fatalf("无法转换 AgentID 环境变量为整数: %v", err)
 		}
 		cfg.WxAgentID = WxAgentID
+	}
+	if os.Getenv("WXUSERID") != "" {
+		cfg.WxUserId = os.Getenv("WXUSERID")
 	}
 	if os.Getenv("MINDELAY") != "" {
 		// 从环境变量读取 AgentID 字符串，并转换为 int

--- a/readme.md
+++ b/readme.md
@@ -11,29 +11,30 @@
 
 ### env环境变量参数
 
-| Parameter     | Notes                                                          |
-|---------------|----------------------------------------------------------------|
-| USERNAME      | 用户名                                                            |
-| PASSWORD      | 账号密码                                                           |
-| TOTPSECRET    | google 二次认证的secret                                             |
-| PROXY         | 代理服务器地址。例如: `http://192.168.50.123:7890`                       |
-| CRONTAB       | 定时任务配置，例如: `2 */2 * * *`                                       |
-| QQPUSH        | 结果推送给的qq号                                                      |
-| QQPUSH_TOKEN  | 对应QQ号推送的token                                                  |
-| M_TEAM_AUTH   | 直接填写m-team的auth字段，自行用浏览器登录，然后抓取到认证信息                           |
-| UA            | M_TEAM_AUTH 对应的user-agent                                      |
-| API_HOST      | api的域名，如果和你的不一样，就换成你自己的。默认值为`api.m-team.io`                    |
-| TIME_OUT      | api访问的超时时间，单位秒。默认值为60                                          |
-| API_REFERER   | api的请求的referer值,如果和你的不一样，就换成你自己的。默认为`https://kp.m-team.cc/`    |
-| WXCORPID      | 企业微信推送通道用。企业ID                                                 |
-| WXAGENTSECRET | 企业微信推送通道用。应用秘钥                                                 |
-| WXAGENTID     | 企业微信推送通道用。应用ID                                                 |
-| MINDELAY      | 定时任务执行随机延迟，最小延迟（分钟）。默认值0                                       |
-| MAXDELAY      | 定时任务执行随机延迟，最大延迟（分钟）。默认值0                                       |
+| Parameter     | Notes                                                         |
+|---------------|---------------------------------------------------------------|
+| USERNAME      | 用户名                                                           |
+| PASSWORD      | 账号密码                                                          |
+| TOTPSECRET    | google 二次认证的secret                                            |
+| PROXY         | 代理服务器地址。例如: `http://192.168.50.123:7890`                      |
+| CRONTAB       | 定时任务配置，例如: `2 */2 * * *`                                      |
+| QQPUSH        | 结果推送给的qq号                                                     |
+| QQPUSH_TOKEN  | 对应QQ号推送的token                                                 |
+| M_TEAM_AUTH   | 直接填写m-team的auth字段，自行用浏览器登录，然后抓取到认证信息                          |
+| UA            | M_TEAM_AUTH 对应的user-agent                                     |
+| API_HOST      | api的域名，如果和你的不一样，就换成你自己的。默认值为`api.m-team.io`                   |
+| TIME_OUT      | api访问的超时时间，单位秒。默认值为60                                         |
+| API_REFERER   | api的请求的referer值,如果和你的不一样，就换成你自己的。默认为`https://kp.m-team.cc/`   |
+| WXCORPID      | 企业微信推送通道用。企业ID                                                |
+| WXAGENTSECRET | 企业微信推送通道用。应用秘钥                                                |
+| WXAGENTID     | 企业微信推送通道用。应用ID                                                |
+| WXUSERID      | 企业微信推送通道用。指定接收消息的成员ID，多个接收者用\|分隔。为空则发送给所有成员         |
+| MINDELAY      | 定时任务执行随机延迟，最小延迟（分钟）。默认值0                                      |
+| MAXDELAY      | 定时任务执行随机延迟，最大延迟（分钟）。默认值0                                      |
 | COOKIE_MODE   | cookie更新模式，"normal"(默认）,连续失败6次才删。"strict"，每次失败都会删掉cookie尝试重新登录 |
-| VERSION       | http_header里面的version版本号，eg 1.1.2                              |
-| WEB_VERSION   | http_header里面的webversion版本号, eg 1120                           |
-| M_TEAM_DID    | http_header里面的did参数。和M_TEAM_AUTH绑定。仅在使用M_TEAM_AUTH的时候需要填       |
+| VERSION       | http_header里面的version版本号，eg 1.1.2                             |
+| WEB_VERSION   | http_header里面的webversion版本号, eg 1120                          |
+| M_TEAM_DID    | http_header里面的did参数。和M_TEAM_AUTH绑定。仅在使用M_TEAM_AUTH的时候需要填      |
 
 ## docker
 


### PR DESCRIPTION
# 优化企业微信推送功能

## 问题描述
目前的企业微信推送功能会将消息发送给所有成员，这可能会对不相关的成员造成不必要的打扰。

## 改动内容

### 1. 新增 WXUSERID 环境变量
- 用于指定消息接收者，支持以下配置方式：
  - 不设置或设为 `@all`：向企业应用的全部成员发送（保持原有行为，向后兼容）
  - 设置为具体成员ID：只发送给指定成员（多个成员用`|`分隔，最多支持1000个）
  ```bash
  # 示例：发送给指定成员
  WXUSERID="zhangsan|lisi"
  ```

### 2. 优化消息发送逻辑
- 删除了 `toparty` 和 `totag` 字段
  - 原因：当 `touser` 为 `@all` 时这些字段会被忽略，保留这些字段没有实际意义

## 参考文档
[企业微信应用消息发送接口文档](https://developer.work.weixin.qq.com/document/path/90236#%E6%96%87%E6%9C%AC%E6%B6%88%E6%81%AF)